### PR TITLE
Add server API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Added a basic Express server with a search endpoint for tasks.

### What changed?

Created a new `server.js` file in the graphite-demo directory that:
- Sets up an Express server on port 3000
- Includes a sample dataset of 3 tasks with IDs and descriptions
- Implements a `/search` endpoint that:
  - Accepts a query parameter
  - Filters tasks based on the query string
  - Sorts the filtered results alphabetically by description
  - Returns the results as JSON

### How to test?

1. Start the server:
   ```
   cd graphite-demo
   node server.js
   ```

2. Test the search endpoint:
   - Visit `http://localhost:3000/search` to see all tasks
   - Try `http://localhost:3000/search?query=report` to filter for tasks containing "report"
   - Try `http://localhost:3000/search?query=project` to filter for tasks containing "project"

### Why make this change?

This provides a simple backend API for task searching functionality, which can be used by a frontend application to display and filter tasks. The implementation includes case-insensitive searching and alphabetical sorting to improve user experience.